### PR TITLE
adding corename propertie to support Solr 5+ Url

### DIFF
--- a/netarchive-arctika/pom.xml
+++ b/netarchive-arctika/pom.xml
@@ -91,6 +91,11 @@ TO BUILD THE JAR WITH DEPENDENCIES USE:
   <artifactId>maven-assembly-plugin</artifactId>
   <version>2.3</version>
   <configuration>
+    <archive>
+      <manifest>
+        <mainClass>dk.statsbiblioteket.netarchivesuite.arctika.builder.IndexBuilder</mainClass>
+      </manifest>
+    </archive>
     <descriptorRefs>
       <descriptorRef>jar-with-dependencies</descriptorRef>
     </descriptorRefs>

--- a/netarchive-arctika/properties/arctika.properties
+++ b/netarchive-arctika/properties/arctika.properties
@@ -19,6 +19,8 @@ arctika.index_target_limit=0.95
       
 arctika.archon_url=http://localhost:9721/netarchive-archon/services
 arctika.solr_url=http://localhost:9731/solr
+#for Solr version >=  5, we must give the corename to construct the url for warc-indexer
+arctika.solr_core_name=
 arctika.shardId=1
 
 #This is the jar file that will be used by the native worker threads

--- a/netarchive-arctika/src/main/java/dk/statsbiblioteket/netarchivesuite/arctika/builder/IndexBuilder.java
+++ b/netarchive-arctika/src/main/java/dk/statsbiblioteket/netarchivesuite/arctika/builder/IndexBuilder.java
@@ -217,9 +217,18 @@ public class IndexBuilder {
             System.out.println(message);
             return false;            
         }
-        
+
+        //if there is a corename in the properties file
+        String solrUrl = config.getSolr_url();
+        if(config.getCoreName() != null && config.getCoreName().length() > 0) {
+            if(!solrUrl.endsWith("/")) {
+               solrUrl += "/";
+            }
+            solrUrl += config.getCoreName();
+        }
+
         jobController.submit(new IndexWorker(
-                nextARC, config.getSolr_url(),
+                nextARC, solrUrl,
                 config.getWorker_maxMemInMb(),
                 config.getWorker_jar_file(),
                 config.getWarcIndexerConfigFile(),

--- a/netarchive-arctika/src/main/java/dk/statsbiblioteket/netarchivesuite/arctika/builder/IndexBuilder.java
+++ b/netarchive-arctika/src/main/java/dk/statsbiblioteket/netarchivesuite/arctika/builder/IndexBuilder.java
@@ -41,7 +41,7 @@ public class IndexBuilder {
     public static void main (String[] args) throws Exception {
         String propertyFile = System.getProperty("ArctikaPropertyFile");
         if (propertyFile == null || "".equals(propertyFile)){
-            String message = "Property file location must be set. Use -DArtikaPropertyFile={path to file}";
+            String message = "Property file location must be set. Use -DArctikaPropertyFile={path to file}";
             System.out.println(message);
             log.error(message);
             System.exit(1);

--- a/netarchive-arctika/src/main/java/dk/statsbiblioteket/netarchivesuite/arctika/builder/IndexBuilderConfig.java
+++ b/netarchive-arctika/src/main/java/dk/statsbiblioteket/netarchivesuite/arctika/builder/IndexBuilderConfig.java
@@ -28,6 +28,7 @@ public class IndexBuilderConfig {
     private String archon_url;
     private String warcIndexerConfigFile;
     private String solr_url;
+    private String solr_core_name;
     private String worker_temp_dir="/tmp"; 
     
     public IndexBuilderConfig(String configFilePath) throws Exception {
@@ -117,6 +118,14 @@ public class IndexBuilderConfig {
     public void setSolr_url(String solr_url) {
         this.solr_url = solr_url;
     }
+    
+    public String getCoreName() {
+        return solr_core_name;
+    }
+   
+    public void setCoreName(String solr_core_name) {
+        this.solr_core_name = solr_core_name;
+    } 
 
     public String getWarcIndexerConfigFile() {
         return warcIndexerConfigFile;
@@ -167,6 +176,7 @@ public class IndexBuilderConfig {
         shardId = Integer.parseInt(serviceProperties.getProperty("arctika.shardId"));
         archon_url = serviceProperties.getProperty("arctika.archon_url");
         solr_url = serviceProperties.getProperty("arctika.solr_url");
+        solr_core_name=serviceProperties.getProperty("arctika.solr_core_name");
         warcIndexerConfigFile = serviceProperties.getProperty("arctika.worker.warcindexer.configfile");        
         worker_jar_file = serviceProperties.getProperty("arctika.worker.index.jar.file");
         worker_temp_dir = serviceProperties.getProperty("arctika.worker.tmp.dir");         
@@ -182,7 +192,8 @@ public class IndexBuilderConfig {
         log.info("Property: shardId = " + shardId);
         log.info("Property: archon_url = " + archon_url);
         log.info("Property: warcIndexerConfigFile = " +  warcIndexerConfigFile );
-        log.info("Property: solr_url = " + solr_url);       
+        log.info("Property: solr_url = " + solr_url);
+        log.info("Property: solr_core_name = " + solr_core_name);
     }
 
 }

--- a/netarchive-arctika/src/main/java/dk/statsbiblioteket/netarchivesuite/arctika/builder/IndexWorker.java
+++ b/netarchive-arctika/src/main/java/dk/statsbiblioteket/netarchivesuite/arctika/builder/IndexWorker.java
@@ -96,6 +96,7 @@ public class IndexWorker implements Callable<IndexWorker> {
              throw new IllegalArgumentException("Warc indexer config file not found:'"+configFile+"'");
          }
          ProcessRunner runner = new ProcessRunner("java",
+                 "-Dfile.encoding=UTF-8",
                  "-Xmx"+maxMemInMb+"M", //-Xmx256M etc              
                  "-Djava.io.tmpdir="+tmpDir,                                   
                  "-jar",


### PR DESCRIPTION
Hello,

While trying to use Arctika with Solr 5+, we face an issue with the propertie **arctika.solr_url**.
We have the following URL for Solr :
- localhost:8981/solr for the solr base address
- localhost:8981/solr/discovery for the address of the **discovery** core

If **arctika.solr_url=localhost:8981/solr/discovery** in Arctika the method **getStatus()** of **ArctikaSolrJClient.java** calls **\<arctika.solr_url\>/admin/cores** and it will fail, as **localhost:8981/solr/discovery/admin/cores** doesn't exist.

If **arctika.solr_url=localhost:8981/solr** the warc-indexer process will fail, as the call to  **\<arctika.solr_url\>/update** is not correct (**localhost:8981/solr/discovery/update** is the right URL).

One way to correct this is to add a corename propertie, and if this propertie exists, we append it to the Solr base URL for warc-indexer.

Moreover, in the pom.xml, we propose to add the \<mainClass\> tag in the maven-assembly-plugin, in order to have a executable jar file while compiling with
```
mvn compile assembly:single
```

We also have some trouble with encoding, that is why we'd like to add  "-Dfile.encoding=UTF-8" parameter